### PR TITLE
Update meta.py target ratios

### DIFF
--- a/census/meta.py
+++ b/census/meta.py
@@ -50,7 +50,8 @@ if __name__ == "__main__":
     # targets = filter(lambda x: x != d_0 and int(float(x) * 10) ==
     #                 float(x) * 10, os.listdir(get_models_path(args.filter, "adv")))
     if args.trg is None:
-        targets = sorted(['0.2,0.5', '0.5,0.2', '0.1,0.5'])
+        #targets = sorted(['0.2,0.5', '0.5,0.2', '0.1,0.5'])
+        targets = sorted(['0.0', '0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0'])
     else:
         lst = eval(args.trg)
         targets = []


### PR DESCRIPTION
While I was trying to reproduce this experiment, I ran into errors concerning the target ratios in the meta.py file. I initially thought the ratios should be split and used for the positive and negative representations of the model, however the code only compiled when using single alpha values for the target ratios instead of pairs.