### PR TITLE
Update data_utils.py

### DIFF
--- a/census/data_utils.py
+++ b/census/data_utils.py
@@ -16,7 +16,7 @@ SUPPORTED_RATIOS = ["0.0", "0.1", "0.2", "0.3",
 
 
 # US Income dataset
-class CensusIncome:
+class CensusTwo:
     def __init__(self, path=BASE_DATA_DIR):
         self.urls = [
             "http://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data",
@@ -218,7 +218,7 @@ def cal_n(df, con, ratio):
 # Wrapper for easier access to dataset
 class CensusWrapper:
     def __init__(self, filter_prop="none", ratio=0.5, split="all"):
-        self.ds = CensusIncome()
+        self.ds = CensusTwo()
         self.split = split
         self.ratio = ratio
         self.filter_prop = filter_prop


### PR DESCRIPTION
The perf_tests.py file attempts to import the CensusTwo and CensusWrapper classes from the data_utils.py file, however, currently only the CensusWrapper class exists within data_utils.py. I assumed that the CensusIncome class referred to the CensusTwo class mentioned in perf_tests.py, and replaced the name of the class.